### PR TITLE
Replaces block subscriptions in ethrpc with new block stream.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,7 +22,7 @@
             "internalConsoleOptions": "openOnSessionStart"
         },
         {
-            // docker run --rm -p 9229:9229 --name=ethrpc ethrpc --debug-brk --inspect --colors test/stub-node-only.js
+            // docker run --rm -p 9229:9229 --name=ethrpc ethrpc --debug-brk --inspect test/stub-node-only.js
             "type": "node2",
             "request": "attach",
             "name": "Attach to Docker",

--- a/src/transport/ipc-transport.js
+++ b/src/transport/ipc-transport.js
@@ -53,7 +53,7 @@ IpcTransport.prototype.submitRpcRequest = function (rpcJso, errorCallback) {
     });
   } catch (error) {
     if (error.code === "EPIPE") error.retryable = true;
-    errorCallback(error);
+    setTimeout(function() { errorCallback(error); });
   }
 };
 

--- a/test/stub-node-only.js
+++ b/test/stub-node-only.js
@@ -57,7 +57,8 @@ describe("tests that only work against stub server", function () {
           });
         });
 
-        it("starts connected > uses connection > loses connection > uses connection > reconnects > uses connection", function (done) {
+        // NOTE: this test is brittle on Linux.  see: https://github.com/nodejs/node/issues/11918
+        it("starts connected > uses connection > loses connection > uses connection > reconnects > uses connection (brittle)", function (done) {
           this.timeout(6000);
           stubRpcServer.addResponder(function (request) { if (request.method === "net_version") return "apple" });
           helpers.rpcConnect(transportType, transportAddress, function () {


### PR DESCRIPTION
Tweaked the way transport reconnect subscriptions worked since the old way was lame (poor abstraction) and complicated integration with the new block stream.

Updates `ethereumjs-stub-rpc-server` which contains a bugfix that prevented the tests from passing.