### PR TITLE
Fixes a bug on connect where it wasn't falling back to reasonable defaults.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -157,7 +157,7 @@ module.exports = {
       // ensure we can do basic JSON-RPC over this connection
       this.version(function (errorOrResult) {
         if (errorOrResult instanceof Error || errorOrResult.error) return initialConnectCallback(errorOrResult);
-        this.createBlockAndLogStreamer({ pollingIntervalMilliseconds: configuration.pollingIntervalMilliseconds, blockRetention: configuration.blockRetention }, createTransportAdapter(this));
+        this.createBlockAndLogStreamer({ pollingIntervalMilliseconds: this.configuration.pollingIntervalMilliseconds, blockRetention: this.configuration.blockRetention }, createTransportAdapter(this));
         this.internalState.blockAndLogStreamer.subscribeToOnBlockAdded(this.onNewBlock.bind(this));
         initialConnectCallback(null);
       }.bind(this));


### PR DESCRIPTION
This is pretty severe as an `undefined` `pollingIntervalMilliseconds` results in the block poller spamming the node for new blocks (effectively `setTimeout(callback, 0)`).