### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "bignumber.js": "2.3.0",
     "browser-request": "0.3.3",
     "clone": "1.0.2",
-    "ethereumjs-blockstream": "2.0.6",
+    "ethereumjs-blockstream": "2.0.7",
     "ethereumjs-tx": "1.3.1",
     "immutable-delete": "1.0.1",
     "keccak": "1.2.0",


### PR DESCRIPTION
Bumps ethereumjs-blockstream version to latest in order to address issue when running `augur` against a local webpack dev environment.