### PR TITLE
Remove Node 7 version from travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ env:
 
 node_js:
   - "8"
-  - "7"
   - "6"
 
 addons:


### PR DESCRIPTION
I think it is not worth to fix Node 7 test run, since the version is [not supported](https://github.com/nodejs/Release) any more, so I removed it from the travis build file to get the build passing again.