### PR TITLE
Update .babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
-  "presets": [["es2015", { "loose": true, "modules": false }], "stage-0"],
+  "presets": [["env", { "loose": true, "modules": false }], "stage-0"],
   "compact": false
 }


### PR DESCRIPTION
es2015 is deprecated in favor of env, this change has been made in package.json but hasn't been updated in the babelrc file.