### PR TITLE
emit-disconnect-events

### DIFF
--- a/src/transport/ws-transport.js
+++ b/src/transport/ws-transport.js
@@ -34,7 +34,7 @@ WsTransport.prototype.connect = function (callback) {
       console.error("websocket", self.address, "closed:", event.code, event.reason);
       var keys = Object.keys(self.disconnectListeners);
       var listeners = self.disconnectListeners;
-      keys.forEach(function(key) {
+      keys.forEach(function (key) {
         return listeners[key]();
       });
       callback(new Error("Web socket closed without opening, usually means failed connection."));
@@ -46,8 +46,8 @@ WsTransport.prototype.connect = function (callback) {
 WsTransport.prototype.submitRpcRequest = function (rpcJso, errorCallback) {
   try {
     if (this.webSocketClient.readyState === 3) {
-      var error = new Error("Websocket Disconnected"); error.retryable = true;
-      return errorCallback(error);
+      var err = new Error("Websocket Disconnected"); err.retryable = true;
+      return errorCallback(err);
     }
     this.webSocketClient.send(JSON.stringify(rpcJso));
   } catch (error) {

--- a/src/transport/ws-transport.js
+++ b/src/transport/ws-transport.js
@@ -32,6 +32,11 @@ WsTransport.prototype.connect = function (callback) {
   this.webSocketClient.onclose = function (event) {
     if (event && event.code !== 1000) {
       console.error("websocket", self.address, "closed:", event.code, event.reason);
+      var keys = Object.keys(self.disconnectListeners);
+      var listeners = self.disconnectListeners;
+      keys.forEach(function(key) {
+        return listeners[key]();
+      });
       callback(new Error("Web socket closed without opening, usually means failed connection."));
     }
     callback = function () { };
@@ -40,6 +45,10 @@ WsTransport.prototype.connect = function (callback) {
 
 WsTransport.prototype.submitRpcRequest = function (rpcJso, errorCallback) {
   try {
+    if (this.webSocketClient.readyState === 3) {
+      var error = new Error("Websocket Disconnected"); error.retryable = true;
+      return errorCallback(error);
+    }
     this.webSocketClient.send(JSON.stringify(rpcJso));
   } catch (error) {
     if (error.code === "INVALID_STATE_ERR") error.retryable = true;


### PR DESCRIPTION
added the emission of disconnection events when wsTransport fires an onClose event. also added proper error handling if the wsc is in readyState 3, prior to this the try/catch wasnt passing the error to the catch in the event of a disconnected wsc