### PR TITLE
Estimate gas by param

### DIFF
--- a/src/transact/call-or-send-transaction.js
+++ b/src/transact/call-or-send-transaction.js
@@ -15,7 +15,8 @@ var errors = require("../errors/codes");
  *   signature: <function signature, e.g. "iia"> (string)
  *   params: <parameters passed to the function> (optional)
  *   returns: <"number[]", "int", "BigNumber", or "string" (default)>
- *   send: <true to sendTransaction, false to call (default)>
+ *   send: <true to sendTransaction, false to estimateGas or call (default)>
+ *   estimateGas: <true to estimateGas, false to call>
  * }
  */
 function callOrSendTransaction(payload, callback) {
@@ -27,10 +28,12 @@ function callOrSendTransaction(payload, callback) {
     }
     packaged = packageRequest(payload);
     if (getState().debug.broadcast) console.log("packaged:", packaged);
-    if (payload.send) {
-      return dispatch(eth.sendTransaction(packageRequest(payload), callback));
+    if (payload.estimateGas) {
+      return dispatch(eth.estimateGas([packaged, "latest"], callback));
+    } else if (payload.send) {
+      return dispatch(eth.sendTransaction(packaged, callback));
     }
-    return dispatch(eth.call([packageRequest(payload), "latest"], callback));
+    return dispatch(eth.call([packaged, "latest"], callback));
   };
 }
 

--- a/src/transport/ws-transport.js
+++ b/src/transport/ws-transport.js
@@ -17,7 +17,7 @@ WsTransport.prototype.connect = function (callback) {
   this.webSocketClient = new WebSocketClient(this.address, undefined, undefined, undefined, { timeout: this.timeout });
   messageHandler = function () { };
   this.webSocketClient.onopen = function () {
-    console.log("websocket", self.address, "opened");
+    //console.log("websocket", self.address, "opened");
     callback(null);
     callback = function () { };
     messageHandler = self.messageHandler;
@@ -32,7 +32,7 @@ WsTransport.prototype.connect = function (callback) {
   };
   this.webSocketClient.onclose = function (event) {
     if (event && event.code !== 1000) {
-      console.error("websocket", self.address, "closed:", event.code, event.reason);
+      ///console.error("websocket", self.address, "closed:", event.code, event.reason);
       var keys = Object.keys(self.disconnectListeners);
       var listeners = self.disconnectListeners;
       keys.forEach(function (key) {

--- a/test/stub-node-only.js
+++ b/test/stub-node-only.js
@@ -1168,7 +1168,7 @@ describe("tests that only work against stub server", function () {
             assert.strictEqual(result, "0x12345");
             done();
           }
-          function onFailure(error) { assert.isFalse(true, "onFailure should not have been called: " + error, +"\n" + err.stack); }
+          function onFailure(error) { assert.isFalse(true, "onFailure should not have been called: " + error); }
           server.addResponder(function (jso) {
             if (jso.method === "eth_estimateGas") return "0x12345";
           });

--- a/test/stub-node-only.js
+++ b/test/stub-node-only.js
@@ -1162,6 +1162,21 @@ describe("tests that only work against stub server", function () {
           rpc.transact(createReasonableTransactPayload(), null, null, onSent, onSuccess, onFailure);
         });
 
+        it.only("should send eth_estimateGas from transact", function (done) {
+          function onSent(result) { }
+          function onSuccess(result) {
+            assert.strictEqual(result, "0x12345");
+            done();
+          }
+          function onFailure(error) { assert.isFalse(true, "onFailure should not have been called: " + error, +"\n" + err.stack); }
+          server.addResponder(function (jso) {
+            if (jso.method === "eth_estimateGas") return "0x12345";
+          });
+          const payload = createReasonableTransactPayload();
+          payload.estimateGas = true;
+          rpc.transact(payload, null, null, onSent, onSuccess, onFailure);
+        });
+
         it("ensureLatestBlock", function (done) {
           clearInterval(interval);
           helpers.rpcConnect(transportType, transportAddress, function () {
@@ -1217,6 +1232,31 @@ describe("tests that only work against stub server", function () {
             params: []
           };
           server.addResponder(function (jso) { if (jso.method === "eth_call") return expectedResults; });
+          rpc.callOrSendTransaction(payload, function (resultOrError) {
+            assert.strictEqual(resultOrError, expectedResults);
+            done();
+          });
+        });
+
+        it("gets the gas price of a transaction", function (done) {
+          server.addExpectation(function (jso) {
+            return jso.method === "eth_estimateGas"
+              && jso.params[0].from === "0x00bae5113ee9f252cceb0001205b88fad175461a"
+              && jso.params[0].to === "0x482c57abdce592b39434e3f619ffc3db62ab6d01"
+              && jso.params[0].value === "0xfffffffff"
+              && jso.params[1] === "latest";
+          });
+          var expectedResults = "0x12345";
+          var payload = {
+            estimateGas: true,
+            name: "getBranches",
+            returns: "bytes32[]",
+            from: "0x00bae5113ee9f252cceb0001205b88fad175461a",
+            to: "0x482c57abdce592b39434e3f619ffc3db62ab6d01",
+            gas: "0xfffffffff",
+            params: []
+          };
+          server.addResponder(function (jso) { if (jso.method === "eth_estimateGas") return expectedResults; });
           rpc.callOrSendTransaction(payload, function (resultOrError) {
             assert.strictEqual(resultOrError, expectedResults);
             done();

--- a/test/stub-node-only.js
+++ b/test/stub-node-only.js
@@ -1162,7 +1162,7 @@ describe("tests that only work against stub server", function () {
           rpc.transact(createReasonableTransactPayload(), null, null, onSent, onSuccess, onFailure);
         });
 
-        it.only("should send eth_estimateGas from transact", function (done) {
+        it("should send eth_estimateGas from transact", function (done) {
           function onSent(result) { }
           function onSuccess(result) {
             assert.strictEqual(result, "0x12345");

--- a/test/stub-node-only.js
+++ b/test/stub-node-only.js
@@ -1172,7 +1172,7 @@ describe("tests that only work against stub server", function () {
           server.addResponder(function (jso) {
             if (jso.method === "eth_estimateGas") return "0x12345";
           });
-          const payload = createReasonableTransactPayload();
+          var payload = createReasonableTransactPayload();
           payload.estimateGas = true;
           rpc.transact(payload, null, null, onSent, onSuccess, onFailure);
         });


### PR DESCRIPTION
This patch enables estimating gas for a transaction simply by adding `estimateGas: true` to the tx object on the transaction payload. This is handy for testing code which executes transactions as well as easily moving from gas-getting to execution without doing extra serialization.