### PR TITLE
Include error (event) object when disconnnect listeners are called, i…

### DIFF
--- a/src/transport/abstract-transport.js
+++ b/src/transport/abstract-transport.js
@@ -159,13 +159,14 @@ function processWork(abstractTransport, rpcObject) {
       // if this is the first retriable failure then initiate a reconnect
       if (abstractTransport.connected) {
         abstractTransport.connected = false;
-        notifyDisconnectListeners(abstractTransport);
+        notifyDisconnectListeners(abstractTransport, error);
         reconnect(abstractTransport);
       }
     } else {
       // if we aren't going to retry the request, let the user know that
       // something went wrong so they can handle it
       error.data = rpcObject;
+      notifyDisconnectListeners(abstractTransport, error);
       abstractTransport.messageHandler(error);
     }
   });
@@ -205,12 +206,12 @@ function notifyReconnectListeners(abstractTransport) {
  * Notify all disconnect listeners of a reconect
  *
  */
-function notifyDisconnectListeners(abstractTransport) {
+function notifyDisconnectListeners(abstractTransport, error) {
   Object.keys(abstractTransport.disconnectListeners).forEach(function (key) {
     if (typeof abstractTransport.disconnectListeners[key] !== "function") {
       delete abstractTransport.disconnectListeners[key];
     } else {
-      abstractTransport.disconnectListeners[key]();
+      abstractTransport.disconnectListeners[key](error);
     }
   });
 }

--- a/src/transport/ipc-transport.js
+++ b/src/transport/ipc-transport.js
@@ -7,7 +7,6 @@ var AbstractTransport = require("./abstract-transport.js");
 
 function IpcTransport(address, timeout, messageHandler, initialConnectCallback) {
   AbstractTransport.call(this, address, timeout, messageHandler);
-
   this.initialConnect(initialConnectCallback);
 }
 
@@ -15,30 +14,37 @@ IpcTransport.prototype = Object.create(AbstractTransport.prototype);
 
 IpcTransport.prototype.constructor = IpcTransport;
 
-IpcTransport.prototype.connect = function (callback) {
+IpcTransport.prototype.connect = function (initialCallback) {
+  var self = this;
+  var initialCallbackCalled = false;
+  var callback = function (err) {
+    initialCallbackCalled = true;
+    initialCallback(err);
+  };
   this.ipcClient = net.connect({ path: this.address });
   this.ipcClient.on("connect", function () {
-    callback(null);
-    callback = function () { };
+    console.log("IPC socket connected", self.address);
+    if (!initialCallbackCalled) callback(null);
     // FIXME: UTF surrogates that cross buffer boundaries will break oboe (https://github.com/jimhigson/oboe.js/issues/133)
-    oboe(this.ipcClient).done(function (jso) {
+    oboe(self.ipcClient).done(function (jso) {
       // FIXME: oboe sometimes gives an empty object for no apparent reason, ignore it
       if (Object.keys(jso).length === 0 && typeof jso === "object") { return; }
-      this.messageHandler(null, jso);
-    }.bind(this));
-  }.bind(this));
+      self.messageHandler(null, jso);
+    });
+  });
   this.ipcClient.on("data", function (/*message*/) {
     // handled by oboe
   });
   this.ipcClient.on("error", function (error) {
     // CONSIDER: can we capture unhandled errors somehow?  in at least one code path, the same error comes in via an errorCallback passed to `write` where we handle it correctly.  i'm not certain that all sources of errors come from calls to `.write` though, but I'm not sure how to dedupe without monkey patching the IPC client.
-    // if `callback` is not the identity function then it means we haven't connected yet, so fire the callback to let the system know the connect failed.
-    callback(error);
-    callback = function () { };
+    // if `callback` hasn't been called yet, fire the callback to let the system know the connect failed.
+    Object.keys(self.disconnectListeners).forEach(function (key) { self.disconnectListeners[key](error); });
+    if (!initialCallbackCalled) callback(error);
   });
   this.ipcClient.on("end", function () {
-    callback(new Error("IPC socket closed without opening, likely means failed connection."));
-    callback = function () { };
+    console.info("IPC socket closed", self.address);
+    Object.keys(self.disconnectListeners).forEach(function (key) { self.disconnectListeners[key](); });
+    if (!initialCallbackCalled) callback(new Error("IPC socket closed without opening, likely means failed connection."));
   });
 };
 
@@ -52,7 +58,7 @@ IpcTransport.prototype.submitRpcRequest = function (rpcJso, errorCallback) {
     });
   } catch (error) {
     if (error.code === "EPIPE") error.retryable = true;
-    setTimeout(function () { errorCallback(error); });
+    setTimeout(function () { errorCallback(error); }, 0);
   }
 };
 


### PR DESCRIPTION
…f available; cleaned up initial callback has-been-called code

Just realized I mixed up branch names -- this PR is for [ch7794] https://app.clubhouse.io/augur/story/7794/add-error-event-object-to-disconnect-events rather than 7539!