### PR TITLE
handle bad urls

### DIFF
--- a/src/transport/transporter.js
+++ b/src/transport/transporter.js
@@ -64,10 +64,15 @@ function Transporter(configuration, messageHandler, debugLogging, callback) {
       if (configuration.ipcAddresses.length === 0) return nextTransport(null);
       someSeries(configuration.ipcAddresses,
         function (ipcAddress, nextAddress) {
-          var ipcTransport = new IpcTransport(ipcAddress, configuration.connectionTimeout, messageHandler, function (error) {
-            if (error !== null) return nextAddress(null);
-            return nextAddress(ipcTransport);
-          });
+          try {
+            var ipcTransport = new IpcTransport(ipcAddress, configuration.connectionTimeout, messageHandler, function (error) {
+              if (error !== null) return nextAddress(null);
+              return nextAddress(ipcTransport);
+            });
+          } catch (err) {
+            console.warn(ipcAddress, err.message);
+            nextAddress(null);
+          }
         },
         nextTransport);
     },
@@ -75,10 +80,15 @@ function Transporter(configuration, messageHandler, debugLogging, callback) {
       if (configuration.wsAddresses.length === 0) return nextTransport(null);
       someSeries(configuration.wsAddresses,
         function (wsAddress, nextAddress) {
-          var wsTransport = new WsTransport(wsAddress, configuration.connectionTimeout, messageHandler, function (error) {
-            if (error !== null) return nextAddress(null);
-            return nextAddress(wsTransport);
-          });
+          try {
+            var wsTransport = new WsTransport(wsAddress, configuration.connectionTimeout, messageHandler, function (error) {
+              if (error !== null) return nextAddress(null);
+              return nextAddress(wsTransport);
+            });
+          } catch (err) {
+            console.warn(wsAddress, err.message);
+            nextAddress(null);
+          }
         },
         nextTransport);
     },
@@ -86,10 +96,15 @@ function Transporter(configuration, messageHandler, debugLogging, callback) {
       if (configuration.httpAddresses.length === 0) return nextTransport(null);
       someSeries(configuration.httpAddresses,
         function (httpAddress, nextAddress) {
-          var httpTransport = new HttpTransport(httpAddress, configuration.connectionTimeout, messageHandler, function (error) {
-            if (error !== null) return nextAddress(null);
-            return nextAddress(httpTransport);
-          });
+          try {
+            var httpTransport = new HttpTransport(httpAddress, configuration.connectionTimeout, messageHandler, function (error) {
+              if (error !== null) return nextAddress(null);
+              return nextAddress(httpTransport);
+            });
+          } catch (err) {
+            console.warn(httpAddress, err.message);
+            nextAddress(null);
+          }
         },
         nextTransport);
     }],

--- a/test/transport/transporter.js
+++ b/test/transport/transporter.js
@@ -103,6 +103,24 @@ describe("transport/transporter", function () {
     });
   });
 
+  it("valid http and ws with unparseable URL, http should be used", function (done) {
+    var configuration = {
+      httpAddresses: ["http://localhost:1338"],
+      wsAddresses: ["blahblahblah"],
+      ipcAddresses: [],
+      connectionTimeout: 1000,
+    };
+    var messageHandler = function (error, message) {
+      assert.isNull(error);
+      assert.deepEqual(message, { jsonrpc: "2.0", id: 0, result: "http server 1" });
+      done();
+    };
+    new Transporter(configuration, messageHandler, false, function (error, transporter) {
+      assert.isNull(error);
+      transporter.blockchainRpc({ id: 0, jsonrpc: "2.0", method: "net_version", params: [] });
+    });
+  });
+
   it("multiple valid http, first should be used", function (done) {
     var configuration = {
       httpAddresses: ["http://localhost:2338", "http://localhost:1338"],


### PR DESCRIPTION
Danz found this bug. When an error occurs that is not async, it is thrown and the whole thing breaks, even if valid transports could be found later.