### PR TITLE
remove resubmit logic

### DIFF
--- a/test/stub-node-only.js
+++ b/test/stub-node-only.js
@@ -1184,18 +1184,20 @@ describe("tests that only work against stub server", function () {
           });
         });
 
-        it("transact pool not accepting", function (done) {
-          function onSent() { }
-          function onSuccess() { assert.isFalse(true, "onSuccess should not have been called"); }
-          function onFailed(err) {
-            assert.strictEqual(err.message, "Maximum number of transaction retry attempts exceeded");
-            assert.strictEqual(err.hash, "0xbadf00dbadf00dbadf00dbadf00dbadf00dbadf00dbadf00dbadf00dbadf" + "0006");
-            done();
-          }
-          server.addResponder(function (jso) { if (jso.method === "eth_call") return "0x12"; });
-          server.addResponder(function (jso) { if (jso.method === "eth_getTransactionByHash") return null; });
-          rpc.transact(createReasonableTransactPayload(), null, null, onSent, onSuccess, onFailed);
-        });
+        // it("transact pool not accepting", function (done) {
+        //   function onSent() {}
+        //   function onSuccess() {
+        //     assert.isFalse(true, "onSuccess should not have been called"); 
+        //   }
+        //   function onFailed(err) {
+        //     assert.strictEqual(err.message, "Maximum number of transaction retry attempts exceeded");
+        //     assert.strictEqual(err.hash, "0xbadf00dbadf00dbadf00dbadf00dbadf00dbadf00dbadf00dbadf00dbadf" + "0006");
+        //     done();
+        //   }
+        //   server.addResponder(function (jso) { if (jso.method === "eth_call") return "0x12"; });
+        //   server.addResponder(function (jso) { if (jso.method === "eth_getTransactionByHash") return null; });
+        //   rpc.transact(createReasonableTransactPayload(), null, null, onSent, onSuccess, onFailed);
+        // });
 
         it("transact", function (done) {
           function onSent() {}

--- a/test/stub-node-only.js
+++ b/test/stub-node-only.js
@@ -1187,7 +1187,7 @@ describe("tests that only work against stub server", function () {
         // it("transact pool not accepting", function (done) {
         //   function onSent() {}
         //   function onSuccess() {
-        //     assert.isFalse(true, "onSuccess should not have been called"); 
+        //     assert.isFalse(true, "onSuccess should not have been called");
         //   }
         //   function onFailed(err) {
         //     assert.strictEqual(err.message, "Maximum number of transaction retry attempts exceeded");


### PR DESCRIPTION
The resubmit logic here doesn't work in practice unless you're connected to a single dedicated node since the tx hash you get back likely wont exist elsewhere. This makes transactions continuously re-fire.