### PR TITLE
Fixing Sec-WebSocket-Protocol error

### DIFF
--- a/src/transport/ws-transport.js
+++ b/src/transport/ws-transport.js
@@ -20,7 +20,7 @@ WsTransport.prototype.connect = function (initialCallback) {
     initialCallbackCalled = true;
     initialCallback(err);
   };
-  this.webSocketClient = new WebSocketClient(this.address, undefined, undefined, undefined, { timeout: this.timeout }, this.websocketClientConfig);
+  this.webSocketClient = new WebSocketClient(this.address, [], undefined, undefined, { timeout: this.timeout }, this.websocketClientConfig);
   var messageHandler = function () {};
   this.webSocketClient.onopen = function () {
     console.log("websocket", self.address, "opened");


### PR DESCRIPTION
I got all my repos linked and working last night so I could test this. I believe all of the constructor parameters get passed into `WebSocketClient.connect`, whose params are listed here: https://github.com/theturtle32/WebSocket-Node/blob/master/docs/WebSocketClient.md#methods. 

According to the link above, changing the second parameter of the `WebSocketClient` constructor from undefined to null seems like it should have worked, but I was getting an error when I did that. However, changing the second param from undefined to [] fixed it for me.

I think all of the other undefined params should probably be set to null too. I was going to test setting them to null this morning before submitting this PR, but I'm getting errors related to linking again this morning and haven't figured them out yet.

@pgebheim Can you try setting these other params to null on your environment to see if this works, and if so, can you please update them in this PR?