### PR TITLE
johndanz/ch17542/update-metamask-to-use-provider

### DIFF
--- a/src/transport/web3-transport.js
+++ b/src/transport/web3-transport.js
@@ -31,7 +31,7 @@ Web3Transport.prototype.close = function () {
 Web3Transport.prototype.submitRpcRequest = function (rpcObject, errorCallback) {
   var web3Provider;
   if (typeof window === "undefined") return errorCallback("attempted to access 'window' outside of a browser, this shouldn't happen");
-  web3Provider = ((window || {}).web3 || {}).currentProvider;
+  web3Provider = (window || {}).ethereum;
   if (!web3Provider) return errorCallback("window.web3.currentProvider no longer available.");
   web3Provider.sendAsync(rpcObject, this.messageHandler.bind(this));
 };

--- a/src/utils/is-global-web3.js
+++ b/src/utils/is-global-web3.js
@@ -3,8 +3,7 @@
 function isGlobalWeb3() {
   if (typeof window === "undefined") return false;
   if (!window) return false;
-  if (!window.web3) return false;
-  if (!window.web3.currentProvider) return false;
+  if (!window.ethereum) return false;
   return true;
 }
 


### PR DESCRIPTION
adjusted the check for globalWeb3 to look for `window.ethereum` instead to handle metamask breaking changes scheduled for November 2nd, 2018.