### PR TITLE
Fix typos in WsTransport.close()

### DIFF
--- a/src/transport/ws-transport.js
+++ b/src/transport/ws-transport.js
@@ -76,10 +76,10 @@ WsTransport.prototype.getTransportName = function () {
 
 WsTransport.prototype.close = function () {
   if (this.webSocketClient.readyState === WebSocketStates.OPEN) {
-    this.websocketClient.close();
-    self.webSocketClient.onmessage = noop;
-    self.webSocketClient.onerror = noop;
-    self.webSocketClient.onopen = noop;
+    this.webSocketClient.close();
+    this.webSocketClient.onmessage = noop;
+    this.webSocketClient.onerror = noop;
+    this.webSocketClient.onopen = noop;
   }
 };
 


### PR DESCRIPTION
Fix typos in `WsTransport.close()`. Practical effect of these typos was to disable any error handling downstream of a `WsTransport.close()` by re-throwing during the error handling.