### PR TITLE
Skip transport disconnect/reconnect on retryable error with HttpTransport

### DIFF
--- a/src/transport/http-transport.js
+++ b/src/transport/http-transport.js
@@ -69,6 +69,7 @@ HttpTransport.prototype.submitRpcRequest = function (rpcObject, errorCallback) {
         if (retries < this.maxRetries) {
           internalState.set("outstandingRequests." + response.id, Object.assign({}, outstandingRequest, {retries: retries + 1}));
           error.retryable = true;
+          error.skipReconnect = true; // in processWork(), in the error callback passed to submitRpcRequest(), we can see that a transport disconnect/reconnect is performed after scheduling this request for a retry. This disconnect/reconnect can break downstream consumers who might interpret the disconnect as being related to a non-retryable issue. So, we'll use skipReconnect to indicate that, for this "0x" result error (which represents transient data unavailability), the reconnect shouldn't be performed by processWork().
           return errorCallback(error);
         }
         return this.messageHandler(null, {


### PR DESCRIPTION
https://app.clubhouse.io/augur/story/17842/ethrpc-don-t-issue-disconnect-on-http-retry-unless-socket-error

Currently, during an ethrpc request, if HttpTransport gets a retryable error,
it'll first disconnect/reconnect the transport before retrying. For the error
"0x" result, which indicates data unavailability, we don't want to call
disconnect, because downstream consumers might interpret the disconnect as being
related to a non-retryable issue.

This change adds a `skipReconnect` flag to skip this disconnect/reconnect.
`skipReconnect` is only used on "0x" error in HttpTransport.

Testing done: added local log messages to verify that disconnect/reconnect was
skipped if and only if skipReconnect flag was set.