### PR TITLE
Ensure no race on pendingCallbacks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ env:
 
 node_js:
   - "8"
-  - "6"
 
 addons:
   apt:


### PR DESCRIPTION
There's a race here with pendingCallbacks in blockstream? The unsubscribe works, but the pending callback could have been queued already. Only happens on node6.