### PR TITLE
sometimes  returns nonce as decimal, ethrpc couldn't handle it. This …

### DIFF
--- a/src/raw-transactions/set-raw-transaction-nonce.js
+++ b/src/raw-transactions/set-raw-transaction-nonce.js
@@ -16,10 +16,11 @@ var RPCError = require("../errors/rpc-error");
 function setRawTransactionNonce(packaged, address, callback) {
   return function (dispatch, getState) {
     dispatch(eth_getTransactionCount([address, "pending"], function (err, transactionCount) {
-      if (getState().debug.tx) console.log("transaction count:", address, transactionCount, parseInt(transactionCount, transactionCount.toString().startsWith("0x") ? 16 : 10));
+      if (getState().debug.tx) console.log("transaction count:", address, transactionCount);
       if (err) return callback(err);
       if (transactionCount == null) return callback(new RPCError("NO_RESPONSE"));
-      callback(null, assign({}, packaged, { nonce: dispatch(verifyRawTransactionNonce(parseInt(transactionCount, transactionCount.toString().startsWith("0x") ? 16 : 10))) }));
+      var txCount = typeof transactionCount === "number" ? transactionCount : parseInt(transactionCount, 16);
+      callback(null, assign({}, packaged, { nonce: dispatch(verifyRawTransactionNonce(txCount)) }));
     }));
   };
 }

--- a/src/raw-transactions/set-raw-transaction-nonce.js
+++ b/src/raw-transactions/set-raw-transaction-nonce.js
@@ -16,10 +16,10 @@ var RPCError = require("../errors/rpc-error");
 function setRawTransactionNonce(packaged, address, callback) {
   return function (dispatch, getState) {
     dispatch(eth_getTransactionCount([address, "pending"], function (err, transactionCount) {
-      if (getState().debug.tx) console.log("transaction count:", address, transactionCount, parseInt(transactionCount, 16));
+      if (getState().debug.tx) console.log("transaction count:", address, transactionCount, parseInt(transactionCount, transactionCount.toString().startsWith("0x") ? 16 : 10));
       if (err) return callback(err);
       if (transactionCount == null) return callback(new RPCError("NO_RESPONSE"));
-      callback(null, assign({}, packaged, { nonce: dispatch(verifyRawTransactionNonce(parseInt(transactionCount, 16))) }));
+      callback(null, assign({}, packaged, { nonce: dispatch(verifyRawTransactionNonce(parseInt(transactionCount, transactionCount.toString().startsWith("0x") ? 16 : 10))) }));
     }));
   };
 }

--- a/test/raw-transactions/set-raw-transaction-nonce.js
+++ b/test/raw-transactions/set-raw-transaction-nonce.js
@@ -46,6 +46,26 @@ describe("raw-transactions/set-raw-transaction-nonce", function () {
     },
   });
   test({
+    description: "21 transactions returned as decimal",
+    params: {
+      packaged: { nonce: 0 },
+      address: "0xb0b",
+    },
+    stub: {
+      eth: {
+        getTransactionCount: function (params, callback) {
+          return function () {
+            callback(null, 12);
+          };
+        },
+      },
+    },
+    assertions: function (err, packaged) {
+      assert.isNull(err);
+      assert.deepEqual(packaged, { nonce: 12 });
+    },
+  });
+  test({
     description: "Error from eth_getTransactionCount",
     params: {
       packaged: { nonce: 0 },


### PR DESCRIPTION
…occurs when Metamask is enabled and user is connected via Ledger


https://app.clubhouse.io/augur/story/18127/ledger-issue-can-t-create-market-and-can-t-get-rep-from-faucet


